### PR TITLE
Improvement suggestions

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -10,6 +10,7 @@ and feel of py.test (e.g. progressbar, show tests that fail instantly).
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import unicode_literals
+import ConfigParser
 import locale
 import os
 import re
@@ -75,6 +76,22 @@ def pytest_addoption(parser):
             "disable pytest-sugar"
         )
     )
+
+
+def pytest_sessionstart(session):
+    config = ConfigParser.ConfigParser()
+    config.read(['pytest-sugar.conf', os.path.expanduser('~/.pytest-sugar.conf')])
+
+    for key in THEME:
+        if not config.has_option('sugar', key):
+            continue
+
+        value = config.get("sugar", key)
+        value = value.lower()
+        if value in ('', 'none'):
+            value = None
+
+        THEME[key] = value
 
 
 def strip_colors(text):

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -300,7 +300,7 @@ class SugarTerminalReporter(TerminalReporter):
             for report in self.reports:
                 if report.outcome == 'failed':
                     crashline = self._get_decoded_crashline(report)
-                    print( "      - %s" % crashline)
+                    print( "         - %s" % crashline)
 
         if self.count('xfailed') > 0:
             self.write_line(colored("   % 5d xfailed" % self.count('xfailed'), THEME['fail']))

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -41,8 +41,7 @@ THEME = {
     'name': None,
 }
 PROGRESS_BAR_BLOCKS = [
-    '█', '▉', '▉', '▊', '▊', '▋', '▋', '▌',
-    '▌', '▍', '▍', '▎', '▎', '▏', '▏'
+    ' ', '▏', '▎', '▎', '▍', '▍', '▌', '▌', '▋', '▋', '▊', '▊', '▉', '▉', '█',
 ]
 
 
@@ -170,20 +169,17 @@ class SugarTerminalReporter(TerminalReporter):
             length = LEN_PROGRESS_BAR
             p = float(self.tests_taken) / self.tests_count
             floored = int(p * length)
-            rem = int(round((p * length - floored) * 13))
+            rem = int(round((p * length - floored) * (len(PROGRESS_BAR_BLOCKS) - 1)))
             progressbar = ''
-            progressbar += "%i%% " % round(p*100)
-            progressbar += TERMINAL_COLORS['okgreen']
-            progressbar += TERMINAL_COLORS['gray_bg']
-            progressbar += PROGRESS_BAR_BLOCKS[1] * floored
-            if p == 1.0:
-                progressbar += PROGRESS_BAR_BLOCKS[1]
-            else:
-                progressbar += PROGRESS_BAR_BLOCKS[14 - rem]
-            progressbar += TERMINAL_COLORS['endc']
-            progressbar += TERMINAL_COLORS['gray'] + TERMINAL_COLORS['gray_bg']
-            progressbar += PROGRESS_BAR_BLOCKS[1] * (length - floored)
-            progressbar += TERMINAL_COLORS['endc']
+            progressbar += "% 3i%% " % round(p*100)
+            bar = PROGRESS_BAR_BLOCKS[-1] * floored
+            if rem > 0:
+                bar += PROGRESS_BAR_BLOCKS[rem]
+            bar += ' ' * (LEN_PROGRESS_BAR - len(bar))
+            progressbar += colored(bar,
+                                   THEME['progressbar'],
+                                   'on_' + THEME['progressbar_background'])
+
             return progressbar
 
         append_string = get_progress_bar()

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -24,11 +24,9 @@ from _pytest.terminal import TerminalReporter
 
 __version__ = '0.3.6'
 
-LEN_RIGHT_MARGIN = 5
+LEN_RIGHT_MARGIN = 1
 LEN_PROGRESS_BAR = 10
-LEN_SPACE_BETWEEN_PERCENT_AND_PROGRESS_BAR = 1
-LEN_PERCENT = 3
-LEN_SPACE_BETWEEN_TEST_STATUS_AND_PERCENT = 4
+LEN_PROGRESS_PERCENTAGE = 5
 THEME = {
     'header': 'magenta',
     'skipped': 'blue',
@@ -171,7 +169,7 @@ class SugarTerminalReporter(TerminalReporter):
             floored = int(p * length)
             rem = int(round((p * length - floored) * (len(PROGRESS_BAR_BLOCKS) - 1)))
             progressbar = ''
-            progressbar += "% 3i%% " % round(p*100)
+            progressbar += "%i%% " % round(p*100)
             bar = PROGRESS_BAR_BLOCKS[-1] * floored
             if rem > 0:
                 bar += PROGRESS_BAR_BLOCKS[rem]
@@ -187,7 +185,8 @@ class SugarTerminalReporter(TerminalReporter):
 
     def append_string(self, append_string=''):
         console_width = self._tw.fullwidth
-        num_spaces = console_width - real_string_length(self.current_line) - real_string_length(append_string)
+        num_spaces = console_width - real_string_length(self.current_line) - \
+            real_string_length(append_string) - LEN_RIGHT_MARGIN
         full_line = self.current_line + " " * num_spaces
         full_line += append_string
         return full_line
@@ -204,24 +203,22 @@ class SugarTerminalReporter(TerminalReporter):
             test_location = report.fspath[0:-len(basename)]
             test_name = report.fspath[-len(basename):]
         if print_filename:
-            self.current_line = ("   " +
+            self.current_line = (" " +
                                  colored(test_location, THEME['path']) +
                                  colored(test_name, THEME['name']) + " ")
         else:
-            self.current_line = " " * (4 + len(report.fspath))
+            self.current_line = " " * (2 + len(report.fspath))
         print("")
 
     def reached_last_column_for_test_status(self):
         max_column_for_test_status = (
             self._tw.fullwidth
-            - LEN_RIGHT_MARGIN
+            - LEN_PROGRESS_PERCENTAGE
             - LEN_PROGRESS_BAR
-            - LEN_SPACE_BETWEEN_PERCENT_AND_PROGRESS_BAR
-            - LEN_PERCENT
-            - LEN_SPACE_BETWEEN_TEST_STATUS_AND_PERCENT
+            - LEN_RIGHT_MARGIN
         )
         len_line = real_string_length(self.current_line)
-        return len_line == max_column_for_test_status
+        return len_line >= max_column_for_test_status
 
     def pytest_runtest_logstart(self, nodeid, location):
         # Prevent locationline from being printed since we already

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -265,13 +265,13 @@ class SugarTerminalReporter(TerminalReporter):
             if not path in self.time_taken:
                 self.time_taken[path] = 0
             self.time_taken[path] += time_taken
-            if self.reached_last_column_for_test_status():
-                self.begin_new_line(report, print_filename=False)
         if report.when == 'call':
             path = report.location if self.showlongtestinfo else report.fspath
             if path != self.currentfspath2:
                 self.currentfspath2 = path
                 self.begin_new_line(report, print_filename=True)
+            elif self.reached_last_column_for_test_status():
+                self.begin_new_line(report, print_filename=False)
 
             rep = report
             res = pytest_report_teststatus(report=report)

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -100,7 +100,7 @@ def _pytest_report_teststatus(report):
     if report.passed:
         letter = TERMINAL_COLORS['okgreen']+'✓'+TERMINAL_COLORS['endc']
     elif report.skipped:
-        letter = TERMINAL_COLORS['okblue']+'s'+TERMINAL_COLORS['endc']
+        letter = TERMINAL_COLORS['okblue']+'⚫'+TERMINAL_COLORS['endc']
     elif report.failed:
         letter = TERMINAL_COLORS['fail']+'⨯'+TERMINAL_COLORS['endc']
         if report.when != "call":

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -10,12 +10,16 @@ and feel of py.test (e.g. progressbar, show tests that fail instantly).
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import unicode_literals
-import ConfigParser
 import locale
 import os
 import re
 import sys
 import time
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser
+
 from termcolor import colored
 
 import py
@@ -79,7 +83,7 @@ def pytest_addoption(parser):
 
 
 def pytest_sessionstart(session):
-    config = ConfigParser.ConfigParser()
+    config = ConfigParser()
     config.read(['pytest-sugar.conf', os.path.expanduser('~/.pytest-sugar.conf')])
 
     for key in THEME:

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -208,31 +208,37 @@ class SugarTerminalReporter(TerminalReporter):
     def overwrite(self, line):
         self.writer.write("\r" + line)
 
-    def begin_new_line(self, report, print_filename):
-        basename = os.path.basename(report.fspath)
-        if self.showlongtestinfo:
-            test_location = report.location[0]
-            test_name = report.location[2]
-        else:
-            test_location = report.fspath[0:-len(basename)]
-            test_name = report.fspath[-len(basename):]
-        if print_filename:
-            self.current_line = (" " +
-                                 colored(test_location, THEME['path']) +
-                                 colored(test_name, THEME['name']) + " ")
-        else:
-            self.current_line = " " * (2 + len(report.fspath))
-        print("")
-
-    def reached_last_column_for_test_status(self):
-        max_column_for_test_status = (
+    def get_max_column_for_test_status(self):
+        return (
             self._tw.fullwidth
             - LEN_PROGRESS_PERCENTAGE
             - LEN_PROGRESS_BAR
             - LEN_RIGHT_MARGIN
         )
+
+    def begin_new_line(self, report, print_filename):
+        if len(report.fspath) > self.get_max_column_for_test_status() - 5:
+            fspath = '...' + report.fspath[-(self.get_max_column_for_test_status() - 5 - 5):]
+        else:
+            fspath = report.fspath
+        basename = os.path.basename(fspath)
+        if self.showlongtestinfo:
+            test_location = report.location[0]
+            test_name = report.location[2]
+        else:
+            test_location = fspath[0:-len(basename)]
+            test_name = fspath[-len(basename):]
+        if print_filename:
+            self.current_line = (" " +
+                                 colored(test_location, THEME['path']) +
+                                 colored(test_name, THEME['name']) + " ")
+        else:
+            self.current_line = " " * (2 + len(fspath))
+        print("")
+
+    def reached_last_column_for_test_status(self):
         len_line = real_string_length(self.current_line)
-        return len_line >= max_column_for_test_status
+        return len_line >= self.get_max_column_for_test_status()
 
     def pytest_runtest_logstart(self, nodeid, location):
         # Prevent locationline from being printed since we already

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -106,18 +106,15 @@ def real_string_length(string):
 
 @pytest.mark.trylast
 def pytest_configure(config):
-    global pytest_report_teststatus
-
     if config.option.sugar:
         # Get the standard terminal reporter plugin and replace it with our
         standard_reporter = config.pluginmanager.getplugin('terminalreporter')
         sugar_reporter = SugarTerminalReporter(standard_reporter)
         config.pluginmanager.unregister(standard_reporter)
         config.pluginmanager.register(sugar_reporter, 'terminalreporter')
-        pytest_report_teststatus = _pytest_report_teststatus
 
 
-def _pytest_report_teststatus(report):
+def pytest_report_teststatus(report):
     if report.passed:
         letter = colored('✓', THEME['success'])
     elif report.skipped:

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -357,9 +357,9 @@ class SugarTerminalReporter(TerminalReporter):
         if self.count('failed') > 0:
             self.write_line(colored("   % 5d failed" % self.count('failed'), THEME['fail']))
             for report in self.reports:
-                if report.outcome == 'failed':
+                if report.failed:
                     crashline = self._get_decoded_crashline(report)
-                    print( "         - %s" % crashline)
+                    self.write_line("         - %s" % crashline)
 
         if self.count('xfailed') > 0:
             self.write_line(colored("   % 5d xfailed" % self.count('xfailed'), THEME['fail']))
@@ -380,6 +380,8 @@ class SugarTerminalReporter(TerminalReporter):
             except UnicodeDecodeError:
                 encoding = 'utf-8'
                 crashline = crashline.decode(encoding, errors='replace')
+
+        return crashline
 
     def summary_failures(self):
         # Prevent failure summary from being shown since we already

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -187,13 +187,13 @@ class SugarTerminalReporter(TerminalReporter):
 
     def append_string(self, append_string=''):
         console_width = self._tw.fullwidth
-        num_spaces = console_width - real_string_length(self.current_line)
+        num_spaces = console_width - real_string_length(self.current_line) - real_string_length(append_string)
         full_line = self.current_line + " " * num_spaces
-        full_line = full_line[0:-(len(append_string) - 28)] + append_string
+        full_line += append_string
         return full_line
 
     def overwrite(self, line):
-        self.writer.write("\r" + self.append_string(line))
+        self.writer.write("\r" + line)
 
     def begin_new_line(self, report, print_filename):
         basename = os.path.basename(report.fspath)

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -28,13 +28,13 @@ LEN_SPACE_BETWEEN_PERCENT_AND_PROGRESS_BAR = 1
 LEN_PERCENT = 3
 LEN_SPACE_BETWEEN_TEST_STATUS_AND_PERCENT = 4
 TERMINAL_COLORS = {
-    'header': '\033[95m',
-    'okblue': '\033[94m',
-    'okgreen': '\033[92m',
+    'header': '\033[35m',
+    'okblue': '\033[34m',
+    'okgreen': '\033[32m',
     'gray': '\033[1;30m',
     'gray_bg': '\033[100m',
-    'warning': '\033[93m',
-    'fail': '\033[91m',
+    'warning': '\033[33m',
+    'fail': '\033[31m',
     'endc': '\033[0m'
 }
 PROGRESS_BAR_BLOCKS = [

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -292,7 +292,7 @@ class SugarTerminalReporter(TerminalReporter):
             self.overwrite(self.insert_progress())
             path = os.path.join(os.getcwd(), report.location[0])
             time_taken = time.time() - self.setup_timer
-            if not path in self.time_taken:
+            if path not in self.time_taken:
                 self.time_taken[path] = 0
             self.time_taken[path] += time_taken
         if report.when == 'call':

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -194,6 +194,9 @@ class SugarTerminalReporter(TerminalReporter):
             floored = int(p * length)
             rem = int(round((p * length - floored) * (len(PROGRESS_BAR_BLOCKS) - 1)))
             progressbar = "%i%% " % round(p*100)
+            # make sure we only report 100% at the last test
+            if progressbar == "100% " and self.tests_taken < self.tests_count:
+                progressbar = "99% "
             if self.failed_progress:
                 progressbar = colored(progressbar, THEME['fail'])
 

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -24,7 +24,7 @@ from _pytest.terminal import TerminalReporter
 
 __version__ = '0.3.6'
 
-LEN_RIGHT_MARGIN = 1
+LEN_RIGHT_MARGIN = 0
 LEN_PROGRESS_BAR = 10
 LEN_PROGRESS_PERCENTAGE = 5
 THEME = {

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms='any',
-    install_requires=['pytest>=2.3'],
+    install_requires=['pytest>=2.3', 'termcolor>=1.1.0'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Heyup. I really like pytest-sugar, but it misbehaves in small terminal windows with long test file paths. It also doesn't work with well my color theme (solarized), so I started looking at it and made some adjustments.

Mainly:
 * using termcolor for much easier coloration and configuration
 * simplify the progressbar maths code
 * change the 's' for skipped tests to a circle
 * simplify the space filling logic of full_line
 * reduce the right margin to 0, so the blinking cursor is hidden

Let me know whether you like any of the changes. I'd like to continue in this direction and add:
 * ~~configurable colors via config file~~ [update: now can be done with pytest-sugar.conf or ~/.pytest-sugar.conf]
 * ~~red progressbar / percentage, so it is immediately visible that there was at least one failure, even if it has scrolled out of view already~~ [update: added, percentage and failed progress bar sections could have the same color as the progress bar by default, so one has to enable it explicitly with a theme setting in the config]
 * ~~handling of long file paths, that reach into the progressbar / percentage, probably by shortening the path to ".../rest/of/path.py"~~ [update: also done now]