### PR TITLE
Display path during setup already, if it changed

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -290,6 +290,12 @@ class SugarTerminalReporter(TerminalReporter):
             # Ignore other reports or it will cause duplicated letters
         if report.when == 'setup':
             self.setup_timer = time.time()
+            path = report.location if self.showlongtestinfo else report.fspath
+            if path != self.currentfspath2:
+                self.currentfspath2 = path
+                self.begin_new_line(report, print_filename=True)
+                self.overwrite(self.insert_progress())
+
         if report.when == 'teardown':
             self.tests_taken += 1
             self.overwrite(self.insert_progress())


### PR DESCRIPTION
For long tests the current behaviour might not show the first test for a
long time or linger on displaying the last file even though the
currently running test is in the next file already.