### PR TITLE
Fix error case when deactivating pytest-sugar using --lf together with --nosugar.

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -70,7 +70,8 @@ def pytest_deselected(items):
     if len(items) > 0:
         pluginmanager = items[0].config.pluginmanager
         terminal_reporter = pluginmanager.getplugin('terminalreporter')
-        if terminal_reporter.tests_count > 0:
+        if (hasattr(terminal_reporter, 'tests_count')
+                and terminal_reporter.tests_count > 0):
             terminal_reporter.tests_count -= len(items)
 
 


### PR DESCRIPTION
If ``--lf`` (of the ``pytest-cache``) reruns some failures, but ``pytest-sugar`` is disabled using ``--nosugar``, ``terminal_reporter`` does not seem to have a ``tests_count`` attribute.