### PR TITLE
Added instructions on enabling detailed output with py.test's verbose option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,3 +36,7 @@ To install pytest-sugar::
 Then run your tests with::
 
     $ py.test
+
+If you would like more detailed output (one test per line), then you may use the verbose option::
+
+    $ py.test --verbose 


### PR DESCRIPTION
As per issue #62, I thought it would be worth sending a tiny pull request to explain the behaviour of pytest-sugar when the `--verbose` option is used with py.test.

Cheers
Fotis