### PR TITLE
pytest-sugar 0.5.0 fails with Python 3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 .tox
 dist/
+.cache/

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -9,7 +9,7 @@ and feel of py.test (e.g. progressbar, show tests that fail instantly).
 :copyright: see LICENSE for details
 :license: BSD, see LICENSE for more details.
 """
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 import locale
 import os
 import re


### PR DESCRIPTION
pytest-sugar==0.5.0

See https://travis-ci.org/mozilla-services/syncclient/jobs/84911659

```
  File "/home/travis/build/mozilla-services/syncclient/.tox/py34/lib/python3.4/site-packages/pytest_sugar.py", line 127

    print colored(
```

Please release 0.5.1 ASAP with a fix.