### PR TITLE
Turn off progress meter when progressbar_length=0

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -196,6 +196,9 @@ class SugarTerminalReporter(TerminalReporter):
     def insert_progress(self):
         def get_progress_bar():
             length = LEN_PROGRESS_BAR
+            if not length:
+                return ''
+            
             p = float(self.tests_taken) / self.tests_count
             floored = int(p * length)
             rem = int(round((p * length - floored) * (len(PROGRESS_BAR_BLOCKS) - 1)))


### PR DESCRIPTION
Instead of spewing errors when progressbar_length is set to 0, just hide the progress meter altogether. Note that this does hide the textual percentage as well.