### PR TITLE
Replace one-line tracebacks

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -110,6 +110,13 @@ def pytest_addoption(parser):
             "disable pytest-sugar"
         )
     )
+    group._addoption(
+        '--new-summary', action="store_false",
+        dest="tb_summary", default=True,
+        help=(
+            "Show tests that failed instead of one-line tracebacks"
+        )
+    )
 
 
 def pytest_sessionstart(session):
@@ -413,7 +420,16 @@ class SugarTerminalReporter(TerminalReporter):
         if self.count('failed', when=['call', 'setup', 'teardown']) > 0:
             self.write_line(colored("   % 5d failed" % self.count('failed'), THEME['fail']))
             for report in self.stats['failed']:
-                crashline = self._get_decoded_crashline(report)
+                if self.config.option.tb_summary:
+                    crashline = self._get_decoded_crashline(report)
+                else:
+                    path, name = report.location[0].rsplit('/', 1)
+                    crashline = '%s/%s:%s %s' % (
+                      colored(path, THEME['path']),
+                      colored(name, THEME['name']),
+                      report.location[1] + 1,
+                      colored(report.location[2], THEME['fail'])
+                    )
                 self.write_line("         - %s" % crashline)
 
         if self.count('xfailed') > 0:


### PR DESCRIPTION
I have never found the one-line tracebacks useful because usually the error happens inside some 3rd party library. Still, I figured I would ask you people before making breaking changes (and maybe making it configurable).

Old:
<img width="668" alt="screen shot 2016-03-18 at 21 39 34" src="https://cloud.githubusercontent.com/assets/53298/13890029/1071247e-ed52-11e5-9f3e-a9d00f91900e.png">

New:
<img width="676" alt="screen shot 2016-03-18 at 21 38 13" src="https://cloud.githubusercontent.com/assets/53298/13890041/200d9016-ed52-11e5-9bad-d6d60ba5ac8e.png">