### PR TITLE
Drop support for old Python and pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,28 +4,12 @@ cache: pip
 python:
   - 3.5
 env:
-  - TOXENV=py26-pytest26-supported-xdist
-  - TOXENV=py26-pytest27-supported-xdist
-  - TOXENV=py26-pytest28-supported-xdist
-  - TOXENV=py27-pytest26-supported-xdist
-  - TOXENV=py27-pytest27-supported-xdist
-  - TOXENV=py27-pytest28-supported-xdist
-  - TOXENV=py27-pytest26-unsupported-xdist
-  - TOXENV=py27-pytest27-unsupported-xdist
-  - TOXENV=py27-pytest28-unsupported-xdist
-  - TOXENV=py33-pytest26-supported-xdist
-  - TOXENV=py33-pytest27-supported-xdist
-  - TOXENV=py33-pytest28-supported-xdist
-  - TOXENV=py34-pytest26-supported-xdist
-  - TOXENV=py34-pytest27-supported-xdist
-  - TOXENV=py34-pytest28-supported-xdist
-  - TOXENV=py35-pytest27-supported-xdist
-  - TOXENV=py35-pytest28-supported-xdist
-  - TOXENV=py35-pytest27-unsupported-xdist
-  - TOXENV=py35-pytest28-unsupported-xdist
-  - TOXENV=pypy-pytest26-supported-xdist
-  - TOXENV=pypy-pytest27-supported-xdist
-  - TOXENV=pypy-pytest28-supported-xdist
+  - TOXENV=py27-pytest29-supported-xdist
+  - TOXENV=py27-pytest29-unsupported-xdist
+  - TOXENV=py34-pytest29-supported-xdist
+  - TOXENV=py35-pytest29-supported-xdist
+  - TOXENV=py35-pytest29-unsupported-xdist
+  - TOXENV=pypy-pytest29-supported-xdist
 install: pip install -U tox
 script:
   - tox

--- a/README.rst
+++ b/README.rst
@@ -23,8 +23,8 @@ Requirements
 
 You will need the following prerequisites in order to use pytest-sugar:
 
-- Python 2.6, 2.7, 3.3 or 3.4
-- pytest 2.6.4 or newer
+- Python 2.7, 3.4 or 3.5
+- pytest 2.9.0 or newer
 - pytest-xdist 1.14 or above if you want the progress bar to work while running
   tests in parallel
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,37 +4,19 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26-pytest26-supported-xdist,
-          py26-pytest27-supported-xdist,
-          py26-pytest28-supported-xdist,
-          py27-pytest26-supported-xdist,
-          py27-pytest27-supported-xdist,
-          py27-pytest28-supported-xdist,
-          py27-pytest26-unsupported-xdist,
-          py27-pytest27-unsupported-xdist,
-          py27-pytest28-unsupported-xdist,
-          py33-pytest26-supported-xdist,
-          py33-pytest27-supported-xdist,
-          py33-pytest28-supported-xdist,
-          py34-pytest26-supported-xdist,
-          py34-pytest27-supported-xdist,
-          py34-pytest28-supported-xdist,
-          py35-pytest27-supported-xdist,
-          py35-pytest28-supported-xdist,
-          py35-pytest27-unsupported-xdist,
-          py35-pytest28-unsupported-xdist,
-          pypy-pytest26-supported-xdist,
-          pypy-pytest27-supported-xdist,
-          pypy-pytest28-supported-xdist
+envlist = py27-pytest29-supported-xdist,
+          py27-pytest29-unsupported-xdist,
+          py34-pytest29-supported-xdist,
+          py35-pytest29-supported-xdist,
+          py35-pytest29-unsupported-xdist,
+          pypy-pytest29-supported-xdist
 
 [testenv]
 passenv = CI TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_REQUEST TRAVIS_JOB_ID TRAVIS_REPO_SLUG TRAVIS_COMMIT
 deps =
     codecov>=1.4.0
     pytest-cov
-    pytest26: pytest>=2.6,<2.7
-    pytest27: pytest>=2.7,<2.8
-    pytest28: pytest>=2.8,<2.9
+    pytest29: pytest>=2.9,<2.10
     termcolor>=1.1.0
     supported-xdist: pytest-xdist>=1.14
     unsupported-xdist: pytest-xdist<1.14


### PR DESCRIPTION
Drops the support for the following:
- Python 2.6
- Python 3.3
- pytest 2.6
- pytest 2.7
- pytest 2.8

This won't be affecting anything in practice. Are there any breaking changes in pytest that would prevent people from upgrading? I mostly want to get rid of that massive test matrix we have that takes forever to complete.