### PR TITLE
Allow progressbar_background color to be none.

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -249,6 +249,13 @@ class SugarTerminalReporter(TerminalReporter):
 
             last = 0
             last_theme = None
+
+            progressbar_background = THEME['progressbar_background']
+            if progressbar_background is None:
+                on_color = None
+            else:
+                on_color = 'on_' + progressbar_background
+
             for block, success in self.progress_blocks:
                 if success:
                     theme = THEME['progressbar']
@@ -258,18 +265,18 @@ class SugarTerminalReporter(TerminalReporter):
                 if last < block:
                     progressbar += colored(bar[last:block],
                                            last_theme,
-                                           'on_' + THEME['progressbar_background'])
+                                           on_color)
 
                 progressbar += colored(bar[block],
                                        theme,
-                                       'on_' + THEME['progressbar_background'])
+                                       on_color)
                 last = block + 1
                 last_theme = theme
 
             if last < len(bar):
                 progressbar += colored(bar[last:len(bar)],
                                        last_theme,
-                                       'on_' + THEME['progressbar_background'])
+                                       on_color)
 
             return progressbar
 


### PR DESCRIPTION
With the introduction of --new-summary as additional option to pytest-sugar it is not reasonable to use -p no:sugar anymore to disable pytest-sugar when --new-summary is added in a pytest.ini. This is in particular true for a jenkins server, where a colored output looks scrambled. To circumvent this issue, a `.pytest-sugar.conf` can be added to set the colors to `None`, but the implementation of the 'progressbar_background' is not working with `None` as value. 
This pull request solves this problem.