### PR TITLE
Support startdir in pytest_report_header, closes #97

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -214,7 +214,8 @@ class SugarTerminalReporter(TerminalReporter):
                 sys.platform, verinfo, pytest.__version__, __version__,
             ), bold=True
         )
-        lines = self.config.hook.pytest_report_header(config=self.config)
+        lines = self.config.hook.pytest_report_header(
+            config=self.config, startdir=self.startdir)
         lines.reverse()
         for line in flatten(lines):
             self.write_line(line)

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -26,6 +26,22 @@ class TestTerminalReporter(object):
           '*6 rerun*'
         ])
 
+    def test_report_header(self, testdir):
+        testdir.makeconftest(
+            """
+            def pytest_report_header(startdir):
+                pass
+            """
+        )
+        testdir.makepyfile(
+            """
+            def test():
+                pass
+            """
+        )
+        result = testdir.runpytest()
+        assert result.ret == 0, result.stderr.str()
+
     def test_xpass_and_xfail(self, testdir):
         testdir.makepyfile(
             """


### PR DESCRIPTION
 Closes #97 

`pytest_report_header` received a new `startdir` argument in 2.3.0, see commit https://github.com/pytest-dev/pytest/commit/ccc04b9fc4d88c1e6662257e1d32a4252f1d0c71