### PR TITLE
Write xdist output on correct lines

### DIFF
--- a/faketests/slowtests/test_1.py
+++ b/faketests/slowtests/test_1.py
@@ -1,0 +1,33 @@
+import time
+
+def test_cat1():
+    time.sleep(1.1)
+    assert True
+
+def test_cat2():
+    time.sleep(1.2)
+    assert True
+
+def test_cat3():
+    time.sleep(1.3)
+    assert True
+
+def test_cat4():
+    time.sleep(1.4)
+    assert True
+
+def test_cat5():
+    time.sleep(1.5)
+    assert True
+
+def test_cat6():
+    time.sleep(1.6)
+    assert True
+
+def test_cat7():
+    time.sleep(1.7)
+    assert True
+
+def test_cat8():
+    time.sleep(1.8)
+    assert True

--- a/faketests/slowtests/test_1.py
+++ b/faketests/slowtests/test_1.py
@@ -1,33 +1,8 @@
 import time
+import pytest
 
-def test_cat1():
-    time.sleep(1.1)
-    assert True
-
-def test_cat2():
-    time.sleep(1.2)
-    assert True
-
-def test_cat3():
-    time.sleep(1.3)
-    assert True
-
-def test_cat4():
-    time.sleep(1.4)
-    assert True
-
-def test_cat5():
-    time.sleep(1.5)
-    assert True
-
-def test_cat6():
-    time.sleep(1.6)
-    assert True
-
-def test_cat7():
-    time.sleep(1.7)
-    assert True
-
-def test_cat8():
-    time.sleep(1.8)
+@pytest.mark.parametrize("index", range(7))
+def test_cat(index):
+    """Perform several tests with varying execution times."""
+    time.sleep(1 + (index * 0.1))
     assert True

--- a/faketests/slowtests/test_2.py
+++ b/faketests/slowtests/test_2.py
@@ -1,0 +1,33 @@
+import time
+
+def test_cat1():
+    time.sleep(0.4)
+    assert True
+
+def test_cat2():
+    time.sleep(0.4)
+    assert True
+
+def test_cat3():
+    time.sleep(0.4)
+    assert True
+
+def test_cat4():
+    time.sleep(0.4)
+    assert True
+
+def test_cat5():
+    time.sleep(0.4)
+    assert True
+
+def test_cat6():
+    time.sleep(0.4)
+    assert True
+
+def test_cat7():
+    time.sleep(0.4)
+    assert True
+
+def test_cat8():
+    time.sleep(0.4)
+    assert True

--- a/faketests/slowtests/test_2.py
+++ b/faketests/slowtests/test_2.py
@@ -1,33 +1,8 @@
 import time
+import pytest
 
-def test_cat1():
-    time.sleep(0.4)
-    assert True
-
-def test_cat2():
-    time.sleep(0.4)
-    assert True
-
-def test_cat3():
-    time.sleep(0.4)
-    assert True
-
-def test_cat4():
-    time.sleep(0.4)
-    assert True
-
-def test_cat5():
-    time.sleep(0.4)
-    assert True
-
-def test_cat6():
-    time.sleep(0.4)
-    assert True
-
-def test_cat7():
-    time.sleep(0.4)
-    assert True
-
-def test_cat8():
+@pytest.mark.parametrize("index", range(7))
+def test_cat(index):
+    """Perform several tests with the same execution times."""
     time.sleep(0.4)
     assert True

--- a/faketests/slowtests/test_3.py
+++ b/faketests/slowtests/test_3.py
@@ -1,33 +1,8 @@
 import time
+import pytest
 
-def test_cat1():
-    time.sleep(0.2)
-    assert True
-
-def test_cat2():
-    time.sleep(0.2)
-    assert True
-
-def test_cat3():
-    time.sleep(0.2)
-    assert True
-
-def test_cat4():
-    time.sleep(0.2)
-    assert True
-
-def test_cat5():
-    time.sleep(0.2)
-    assert True
-
-def test_cat6():
-    time.sleep(0.2)
-    assert True
-
-def test_cat7():
-    time.sleep(0.2)
-    assert True
-
-def test_cat8():
-    time.sleep(0.2)
+@pytest.mark.parametrize("index", range(7))
+def test_cat(index):
+    """Perform several tests with varying execution times."""
+    time.sleep(0.2 + (index * 0.1))
     assert True

--- a/faketests/slowtests/test_3.py
+++ b/faketests/slowtests/test_3.py
@@ -1,0 +1,33 @@
+import time
+
+def test_cat1():
+    time.sleep(0.2)
+    assert True
+
+def test_cat2():
+    time.sleep(0.2)
+    assert True
+
+def test_cat3():
+    time.sleep(0.2)
+    assert True
+
+def test_cat4():
+    time.sleep(0.2)
+    assert True
+
+def test_cat5():
+    time.sleep(0.2)
+    assert True
+
+def test_cat6():
+    time.sleep(0.2)
+    assert True
+
+def test_cat7():
+    time.sleep(0.2)
+    assert True
+
+def test_cat8():
+    time.sleep(0.2)
+    assert True

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -460,3 +460,17 @@ class TestTerminalReporter(object):
         result = testdir.runpytest('--force-sugar', '-n2')
 
         assert result.ret == 0, result.stderr.str()
+
+    def test_xdist_verbose(self, testdir):
+        pytest.importorskip("xdist")
+        testdir.makepyfile(
+            """
+            def test_nada():
+                pass
+            def test_zip():
+                pass
+            """
+        )
+        result = testdir.runpytest('--force-sugar', '-n2', '-v')
+
+        assert result.ret == 0, result.stderr.str()


### PR DESCRIPTION
This change improves the output when pytest-sugar is combined with pytest-xdist. Currently, when xdist is used, the reports aren't necessarily run in serial order, and sugar ends up generating a lot of extra lines. This PR allows sugar to move back up and add check marks to the correct line, so a new line doesn't need to be added. Since a picture is worth a thousand words:

Old:
![Old Behavior](http://i.imgur.com/Ckp5DFD.gif)
New:
![New Behavior](http://i.imgur.com/sdxX5vE.gif)