### PR TITLE
Don't crash when no line number in the report

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -491,7 +491,7 @@ class SugarTerminalReporter(TerminalReporter):
                         colored(path, THEME['path']),
                         '/' if path else '',
                         colored(name, THEME['name']),
-                        report.location[1] + 1,
+                        report.location[1] + 1 if report.location[1] else '?',
                         colored(report.location[2], THEME['fail'])
                     )
                 self.write_line("         - %s" % crashline)

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -460,3 +460,20 @@ class TestTerminalReporter(object):
         result = testdir.runpytest('--force-sugar', '-n2')
 
         assert result.ret == 0, result.stderr.str()
+
+    def test_doctest(self, testdir):
+        """ Test doctest-modules """
+
+        testdir.makepyfile(
+            """
+            class ToTest(object):
+                @property
+                def doctest(self):
+                    \"\"\"
+                        >>> Invalid doctest
+                    \"\"\"
+            """
+        )
+        result = testdir.runpytest('--force-sugar', '--doctest-module')
+
+        assert result.ret == 1, result.stderr.str()


### PR DESCRIPTION
When pytest are unable to find the line number of the error, pytest-sugar crash. With this fix it will show a '?' instead of the line number.

Test with:

```python
class A(object):
    @property
    def b(self):
        """
            >>> Invalid doctest
        """
        return None
```

It gives:
```
(pytest-sugar)  moutix@moutix-mint ~ $ pytest --doctest-module test.py 
Test session starts (platform: linux, Python 3.5.2, pytest 3.0.6, pytest-sugar 0.8.0)
rootdir: /home/moutix, inifile: 
plugins: sugar-0.8.0, pylint-0.7.0


―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― [doctest] test.A.b ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
EXAMPLE LOCATION UNKNOWN, not showing all tests of that example
??? >>> Invalid doctest
UNEXPECTED EXCEPTION: SyntaxError('invalid syntax', ('<doctest test.A.b[0]>', 1, 15, 'Invalid doctest\n'))
Traceback (most recent call last):

  File "/usr/lib/python3.5/doctest.py", line 1321, in __run
    compileflags, 1), test.globs)

  File "<doctest test.A.b[0]>", line 1

    Invalid doctest

                  ^

SyntaxError: invalid syntax

/home/moutix/test.py:None: UnexpectedException

 test.py ⨯                                                                                                                                                                                                                   100% ██████████

Results (0.02s):
       1 failed
Traceback (most recent call last):
  File "/home/moutix/.virtualenvs/pytest-sugar/bin/pytest", line 11, in <module>
    sys.exit(main())
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/_pytest/config.py", line 57, in main
    return config.hook.pytest_cmdline_main(config=config)
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/_pytest/vendored_packages/pluggy.py", line 745, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/_pytest/vendored_packages/pluggy.py", line 339, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/_pytest/vendored_packages/pluggy.py", line 334, in <lambda>
    _MultiCall(methods, kwargs, hook.spec_opts).execute()
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/_pytest/vendored_packages/pluggy.py", line 614, in execute
    res = hook_impl.function(*args)
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/_pytest/main.py", line 127, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/_pytest/main.py", line 122, in wrap_session
    exitstatus=session.exitstatus)
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/_pytest/vendored_packages/pluggy.py", line 745, in __call__
    return self._hookexec(self, self._nonwrappers + self._wrappers, kwargs)
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/_pytest/vendored_packages/pluggy.py", line 339, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/_pytest/vendored_packages/pluggy.py", line 334, in <lambda>
    _MultiCall(methods, kwargs, hook.spec_opts).execute()
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/_pytest/vendored_packages/pluggy.py", line 613, in execute
    return _wrapped_call(hook_impl.function(*args), self.execute)
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/_pytest/vendored_packages/pluggy.py", line 250, in _wrapped_call
    wrap_controller.send(call_outcome)
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/_pytest/terminal.py", line 374, in pytest_sessionfinish
    self.summary_stats()
  File "/home/moutix/.virtualenvs/pytest-sugar/lib/python3.5/site-packages/pytest_sugar.py", line 494, in summary_stats
    report.location[1] + 1,
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
```