### PR TITLE
Print correct location for doctest failures

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -487,11 +487,20 @@ class SugarTerminalReporter(TerminalReporter):
                 else:
                     path = os.path.dirname(report.location[0])
                     name = os.path.basename(report.location[0])
+                    # Doctest failure reports have lineno=None at least up to
+                    # pytest==3.0.7, but it is available via longrepr object.
+                    if report.location[1] is not None:
+                        lineno = report.location[1] + 1
+                    else:
+                        try:
+                            lineno = report.longrepr.reprlocation.lineno
+                        except AttributeError:
+                            lineno = None
                     crashline = '%s%s%s:%s %s' % (
                         colored(path, THEME['path']),
                         '/' if path else '',
                         colored(name, THEME['name']),
-                        report.location[1] + 1 if report.location[1] else '?',
+                        lineno if lineno else '?',
                         colored(report.location[2], THEME['fail'])
                     )
                 self.write_line("         - %s" % crashline)

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -477,3 +477,25 @@ class TestTerminalReporter(object):
         result = testdir.runpytest('--force-sugar', '--doctest-module')
 
         assert result.ret == 1, result.stderr.str()
+
+    def test_doctest_lineno(self, testdir):
+        """ Test location reported for doctest-modules """
+
+        testdir.makepyfile(
+            """
+            def foobar():
+                '''
+                >>> foobar()
+                '''
+                raise NotImplementedError
+            """
+        )
+        result = testdir.runpytest('--force-sugar', '--doctest-module')
+
+        assert result.ret == 1, result.stderr.str()
+        result.stdout.fnmatch_lines([
+            'UNEXPECTED EXCEPTION: NotImplementedError()',
+            '*test_doctest_lineno.py:3: UnexpectedException',
+            'Results*:',
+            '*-*test_doctest_lineno.py*:3*',
+        ])


### PR DESCRIPTION
This PR extends the latest fix that prints '?' for line numbers of doctest failures and provides correct line number values


With this PR for a file that looks like this:
```python
def foobar():
    """
    >>> foobar()
    """
    raise NotImplementedError

```

it prints

```
Test session starts (platform: linux, Python 3.6.1, pytest 3.0.6, pytest-sugar 0.8.0)
rootdir: /home/immerrr/sources/pytest-sugar, inifile: 
plugins: sugar-0.8.0


――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― [doctest] doctestmod.foobar ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
002 
003     >>> foobar()
UNEXPECTED EXCEPTION: NotImplementedError()
Traceback (most recent call last):

  File "/home/immerrr/.conda/envs/pytest-sugar/lib/python3.6/doctest.py", line 1330, in __run
    compileflags, 1), test.globs)

  File "<doctest doctestmod.foobar[0]>", line 1, in <module>

  File "/home/immerrr/sources/pytest-sugar/doctestmod.py", line 5, in foobar
    raise NotImplementedError

NotImplementedError

/home/immerrr/sources/pytest-sugar/doctestmod.py:3: UnexpectedException

 doctestmod.py ⨯                                                                                                                                                                100% ██████████

Results (0.03s):
       1 failed
         - doctestmod.py:3 [doctest] doctestmod.foobar

```