### PR TITLE
Fix reported doctest location for pytest 3.2

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -517,13 +517,12 @@ class SugarTerminalReporter(TerminalReporter):
                     name = os.path.basename(report.location[0])
                     # Doctest failure reports have lineno=None at least up to
                     # pytest==3.0.7, but it is available via longrepr object.
-                    if report.location[1] is not None:
-                        lineno = report.location[1] + 1
-                    else:
-                        try:
-                            lineno = report.longrepr.reprlocation.lineno
-                        except AttributeError:
-                            lineno = None
+                    try:
+                        lineno = report.longrepr.reprlocation.lineno
+                    except AttributeError:
+                        lineno = report.location[1]
+                        if lineno is not None:
+                            lineno += 1
                     crashline = '%s%s%s:%s %s' % (
                         colored(path, THEME['path']),
                         '/' if path else '',


### PR DESCRIPTION
It looks like pytest 3.2 sets report.location to the first line of the
docstring containing the doctest, so the old "location is None" condition
doesn't work anymore.

Related to #123 