### PR TITLE
Fix incompatibility with pytest 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,15 @@ addons:
 env:
   - TOXENV=py27-pytest30-supported-xdist
   - TOXENV=py27-pytest31-supported-xdist
+  - TOXENV=py27-pytest34-supported-xdist
   - TOXENV=py27-pytest30-unsupported-xdist
   - TOXENV=py34-pytest30-supported-xdist
   - TOXENV=py34-pytest31-supported-xdist
+  - TOXENV=py34-pytest34-supported-xdist
   - TOXENV=py35-pytest30-supported-xdist
+  - TOXENV=py35-pytest34-supported-xdist
   - TOXENV=py36-pytest30-supported-xdist
+  - TOXENV=py36-pytest34-supported-xdist
   - TOXENV=py35-pytest30-unsupported-xdist
   - TOXENV=pypy-pytest30-supported-xdist
   - TOXENV=pypy-pytest31-supported-xdist

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -390,6 +390,13 @@ class SugarTerminalReporter(TerminalReporter):
         # show the module_name & in verbose mode the test name.
         pass
 
+    if pytest.__version__ >= '3.4':
+
+        def pytest_runtest_logfinish(self):
+            # prevent the default implementation to try to show
+            # pytest's default progress
+            pass
+
     def report_key(self, report):
         """Returns a key to identify which line the report should write to."""
         return report.location if self.showlongtestinfo else report.fspath

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@
 envlist = py{27,34,35,36,py}-pytest30-supported-xdist,
           py{27,35}-pytest30-unsupported-xdist,
           py{27,34,py}-pytest31-supported-xdist
+          py{27,34,py}-pytest34-supported-xdist
 
 [testenv]
 passenv = CI TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_REQUEST TRAVIS_JOB_ID TRAVIS_REPO_SLUG TRAVIS_COMMIT
@@ -15,6 +16,7 @@ deps =
     pytest-cov
     pytest30: pytest>=3.0,<3.1
     pytest31: pytest>=3.1,<3.2
+    pytest34: pytest>=3.4,<3.5
     termcolor>=1.1.0
     supported-xdist: pytest-xdist>=1.14
     unsupported-xdist: pytest-xdist<1.14


### PR DESCRIPTION
`TerminalWriter` implements the new [`pytest_runtest_logfinish`](https://docs.pytest.org/en/latest/writing_plugins.html#_pytest.hookspec.pytest_runtest_logfinish) hook which must be overwritten by `SugarTerminalReporter` to prevent the default implementation from trying to print the current progress.

Fixes #132 