### PR TITLE
Use separate qa tox environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
   - TOXENV=py37-pytest37-supported-xdist
   - TOXENV=pypy-pytest30-supported-xdist
   - TOXENV=pypy-pytest31-supported-xdist
+  - TOXENV=qa
 install: pip install -U tox
 script:
   - tox

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist = py{27,34,35,36,py}-pytest30-supported-xdist,
           py{27,35}-pytest30-unsupported-xdist,
           py{27,34,py}-pytest31-supported-xdist
           py{27,34,py}-pytest34-supported-xdist
+          qa
 
 [testenv]
 passenv = CI TRAVIS_BUILD_ID TRAVIS TRAVIS_BRANCH TRAVIS_JOB_NUMBER TRAVIS_PULL_REQUEST TRAVIS_JOB_ID TRAVIS_REPO_SLUG TRAVIS_COMMIT
@@ -22,8 +23,12 @@ deps =
     supported-xdist: pytest-xdist>=1.14
     unsupported-xdist: pytest-xdist<1.14
     pytest-rerunfailures
-    flake8
 commands =
     py.test --cov=./ {posargs:test_sugar.py}
-    flake8 --exclude faketests,.tox
     codecov -e TOXENV
+
+[testenv:qa]
+deps =
+    flake8
+commands =
+    flake8 {posargs:conftest.py pytest_sugar.py setup.py test_sugar.py}


### PR DESCRIPTION
This allows for having reported this separately on CI, and should speed
up the other builds in general a bit.

Also pass all files explicitly, for me it would run on `.venv` for
example.