### PR TITLE
Fix support for pytest >= 3.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ matrix:
       python: '3.7'
       sudo: required
       dist: xenial
+    - env: TOXENV=py37-pytest310-supported-xdist
+      python: '3.7'
+      sudo: required
+      dist: xenial
 install: pip install -U tox
 script:
   - tox

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -398,7 +398,7 @@ class SugarTerminalReporter(TerminalReporter):
         # show the module_name & in verbose mode the test name.
         pass
 
-    if pytest.__version__ >= '3.4':
+    if tuple(int(x) for x in pytest.__version__.split('.')[:2]) >= (3, 4):
 
         def pytest_runtest_logfinish(self):
             # prevent the default implementation to try to show

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,9 @@
 [tox]
 envlist = py{27,34,35,36,py}-pytest30-supported-xdist,
           py{27,35}-pytest30-unsupported-xdist,
-          py{27,34,py}-pytest31-supported-xdist
-          py{27,34,py}-pytest34-supported-xdist
+          py{27,34,py}-pytest31-supported-xdist,
+          py{27,34,py}-pytest34-supported-xdist,
+          py37-pytest{39,310}-supported-xdist,
           qa
 
 [testenv]
@@ -20,6 +21,7 @@ deps =
     pytest34: pytest>=3.4,<3.5
     pytest37: pytest>=3.7,<3.8
     pytest39: pytest>=3.9,<3.10
+    pytest310: pytest>=3.10,<3.11
     termcolor>=1.1.0
     supported-xdist: pytest-xdist>=1.14
     unsupported-xdist: pytest-xdist<1.14


### PR DESCRIPTION
Fixes the same issue as #160, but without the additional dependency on `packaging`.