### PR TITLE
tests: fix test_item_count_after_pytest_collection_modifyitems

### DIFF
--- a/test_sugar.py
+++ b/test_sugar.py
@@ -269,7 +269,7 @@ class TestTerminalReporter(object):
                 assert 0
             """
         )
-        result = testdir.runpytest('-p no:sugar', '-s')
+        result = testdir.runpytest('-s')
         result.stdout.fnmatch_lines([
             '*test_one_passed*',
             '*100%*',


### PR DESCRIPTION
`-p no:sugar` never worked to disable pytest-sugar, and the test assumes
pytest-sugar is used.

Fixes https://github.com/Frozenball/pytest-sugar/issues/167.